### PR TITLE
Change dev container from Ubuntu to Alpine

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
-  "image": "ttanjo/ldc-ubuntu-musl:1.17.0",
+  "image": "ttanjo/ldc-alpine:1.17.0",
   "runArgs": ["-v", "${env:HOME}${env:USERPROFILE}/.ssh:/root/.ssh-localhost:ro"],
-  "postCreateCommand": "apt-get update && apt-get install -y --no-install-recommends git openssh-client && mkdir -p ~/.ssh && cp -r ~/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/*",
+  "postCreateCommand": "apk --no-cache add git openssh-client && mkdir -p ~/.ssh && cp -r ~/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/*",
   "extensions": ["webfreak.code-d"],
   "settings": {
     "d.dmdPath": "ldmd2",
     "d.stdlibPath": [
-      "/dlang/dc/import"
+      "/dlang/dc/include/d"
     ]
   }
 }

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,12 +14,12 @@ jobs:
         with:
           fetch-depth: 1
       - name: Build dev image
-        run: docker build . -f dev.Dockerfile -t ttanjo/ldc-ubuntu-musl:latest
+        run: docker build . -f dev.Dockerfile -t ttanjo/ldc-alpine:latest
       - name: Upload docker image
         run: |
           echo $DOCKER_TOKEN | docker login -u ttanjo --password-stdin
-          docker tag ttanjo/ldc-ubuntu-musl:latest ttanjo/ldc-ubuntu-musl:${VER}
-          docker push ttanjo/ldc-ubuntu-musl:latest
-          docker push ttanjo/ldc-ubuntu-musl:${VER}
+          docker tag ttanjo/ldc-alpine:latest ttanjo/ldc-alpine:${VER}
+          docker push ttanjo/ldc-alpine:latest
+          docker push ttanjo/ldc-alpine:${VER}
         env:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -68,22 +68,17 @@ There are several ways to execute it.
   ...
   ```
 
-If you need a static linked binary, add `-mtriple=x86_64-alpine-linux-musl -static` to the build command:
+If you need a static linked binary, add `-static` to the build command:
 ```console
 $ ldc2 zatsu-cwl-generator.d # for dynamic link (default)
 $ ldd zatsu-cwl-generator
-        linux-vdso.so.1 (0x00007ffde1327000)
-        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f83cf2d4000)
-        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f83cf0d0000)
-        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f83ceeb1000)
-        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f83ceb13000)
-        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f83ce8fb000)
-        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f83ce50a000)
-        /lib64/ld-linux-x86-64.so.2 (0x00007f83cf718000)
+        /lib/ld-musl-x86_64.so.1 (0x7f476696e000)
+        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x7f4766711000)
+        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f476696e000)
 
-$ ldc2 -mtriple=x86_64-alpine-linux-musl -static zatsu-cwl-generator.d # for static link
-$ ldd zatu-cwl-generator
-        not a dynamic executable
+$ ldc2 -static zatsu-cwl-generator.d # for static link
+$ ldd zatsu-cwl-generator
+/lib/ld-musl-x86_64.so.1: zatsu-cwl-generator: Not a valid dynamic program
 ```
 
 # How to test this program

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,23 +1,94 @@
-FROM dlang2/ldc-ubuntu:1.17.0 AS build
+FROM alpine:3.10 AS build
 
 LABEL maintainer "Tomoya Tanjo <ttanjo@gmail.com>"
 
-ARG DEBCONF_NOWARNINGS=yes
+RUN apk add --no-cache llvm5-libs g++ binutils-gold clang lld \
+                       llvm8-libs llvm8-static llvm8-dev \
+                       cmake ninja zlib-dev curl-dev bash git
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends cmake musl-tools
-RUN CC=musl-gcc ldc-build-runtime --dFlags="-w;-mtriple=x86_64-alpine-linux-musl" BUILD_SHARED_LIBS=OFF
+# Install ldc2
+ARG ldc_ver=1.17.0
+
+RUN wget -O ldc-bin.tar.xz https://github.com/ldc-developers/ldc/releases/download/v1.13.0/ldc2-1.13.0-alpine-linux-x86_64.tar.xz
+RUN tar xf ldc-bin.tar.xz
+RUN wget -O ldc-src.tar.gz https://github.com/ldc-developers/ldc/releases/download/v${ldc_ver}/ldc-${ldc_ver}-src.tar.gz
+RUN tar xf ldc-src.tar.gz
+RUN mkdir ldc-${ldc_ver}-src/build
+WORKDIR ldc-${ldc_ver}-src/build
+RUN cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release \
+          -DD_COMPILER=/ldc2-1.13.0-alpine-linux-x86_64/bin/ldmd2 \
+          -DCMAKE_INSTALL_PREFIX=/dlang/ldc2-${ldc_ver}
+RUN ninja -j4 && ninja install
+WORKDIR /dlang
+RUN ln -s ldc2-${ldc_ver} dc
+RUN cat /dlang/dc/etc/ldc2.conf | \
+    sed -e 's/\("-defaultlib=phobos2-ldc,druntime-ldc",\)/\1 "-gcc=clang", "-linker=lld"/' | \
+    sed -e "s|/dlang/ldc2-${ldc_ver}|%%ldcbinarypath%%/..|g" > ldc2.conf && \
+    mv ldc2.conf /dlang/dc/etc
+
+# The following is to build msgpack-d used by dcd
+RUN sed -e 's/uint \+iov_len/size_t iov_len/' /dlang/dc/include/d/core/sys/posix/sys/uio.d > uio.d
+RUN mv uio.d /dlang/dc/include/d/core/sys/posix/sys/uio.d
+
+ENV PATH=/dlang/dc/bin:$PATH
+
+WORKDIR /
+
+# Install dub
+ARG dub_ver=1.17.0
+
+RUN wget -O dub.tar.gz https://github.com/dlang/dub/archive/v${dub_ver}.tar.gz
+RUN tar xf dub.tar.gz
+WORKDIR dub-${dub_ver}
+RUN ./build.sh
+RUN strip bin/dub
+RUN mv bin/dub /dlang/dc/bin
+
+WORKDIR /
+
+# Install rdmd
+ARG rdmd_ver=2.088.0
+
+RUN wget -O tools.tar.gz https://github.com/dlang/tools/archive/v${rdmd_ver}.tar.gz
+RUN tar xf tools.tar.gz
+WORKDIR tools-${rdmd_ver}
+RUN dub build -b release :rdmd
+RUN strip dtools_rdmd
+RUN mv dtools_rdmd /dlang/dc/bin/rdmd
+
+WORKDIR /
+
+RUN mkdir -p /dlang/.code-d/bin
+
+# Install code-d
+# It cannot be built with 0.4.1 (#65)
+#ARG served_ver=0.4.1
+#RUN wget -O serve-d.tar.gz https://github.com/Pure-D/serve-d/archive/v${served_ver}.tar.gz
+#RUN tar xf serve-d.tar.gz
+RUN wget -O serve-d.zip https://github.com/Pure-D/serve-d/archive/master.zip
+RUN unzip serve-d.zip
+WORKDIR serve-d-master
+RUN dub build -b release
+RUN strip serve-d
+RUN mv serve-d /dlang/.code-d/bin
+
+WORKDIR /
+
+# Install dcd
+ARG dcd_ver=0.12.0
+RUN git clone https://github.com/dlang-community/DCD.git -b v${dcd_ver}
+WORKDIR DCD
+RUN dub build -b release -c client
+RUN dub build -b release -c server
+RUN strip dcd-client dcd-server
+RUN mv bin/dcd-* /dlang/.code-d/bin
 
 
-FROM dlang2/ldc-ubuntu:1.17.0
+FROM alpine:3.10
 
-ARG DEBCONF_NOWARNINGS=yes
+ENV PATH=/dlang/dc/bin:$PATH
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends musl-tools
+COPY --from=build /dlang /dlang
 
-COPY --from=build /ldc-build-runtime.tmp/lib /dlang/dc/lib-musl
-COPY ldc2-musl.conf /ldc2.conf.musl
-
-RUN cat /ldc2.conf.musl >> /dlang/dc/etc/ldc2.conf && \
-    rm /ldc2.conf.musl
+RUN mv /dlang/.code-d /root
+RUN apk add --no-cache clang lld tzdata musl-dev gcc curl-dev


### PR DESCRIPTION
Currently remote container for this repository uses `ttanjo/ldc-ubuntu-musl:1.17.0`
 based on `dlang2/ldc-ubuntu`.

However, the file size of `ldc-ubuntu-musl` is about 1.15GB. It is too large for the remote container.

This PR changes the container image from `ttanjo/ldc-ubuntu-musl` to `ttanjo/ldc-alpine` that is based on Alpine Linux and its size is about 530MB.

Once this request is merged, `ttanjo/ldc-ubuntu-musl` will be deprecated and will be deleted.
